### PR TITLE
Adds support for us region

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Options:
   --backup-dir TEXT     Directory to store activities (default: ./coros_activities)
   --email TEXT          Coros account email
   --password TEXT       Coros password (prompts if omitted for security)
+  --region [eu|us]      Coros account region (default: eu)
+  --base-url TEXT       Override the API host directly. Takes precedence over --region.
   --format TEXT         Export formats: fit, tcx, gpx, kml or csv
   --verbose             Enable debug logging
   --help                Show this message
@@ -169,6 +171,12 @@ coros-backup --format fit --format tcx --format gpx
 
 # Enable verbose output
 coros-backup --backup-dir ~/coros --verbose
+
+# Backup a US region account
+coros-backup --region us
+
+# Point at a custom API host (overrides --region)
+coros-backup --base-url https://teamapi.coros.com
 ```
 
 ## Architecture Notes

--- a/src/corosexport/cli/backup.py
+++ b/src/corosexport/cli/backup.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
     "--region",
     type=click.Choice(["eu", "us"], case_sensitive=False),
     default="eu",
-    help="Coros account region, default eu)",
+    help="Coros account region (default: eu)",
 )
 @click.option(
     "--base-url",
@@ -111,17 +111,13 @@ def main(
     if base_url:
         client_base_url = base_url.rstrip("/")
     else:
-        if region not in REGION_HOSTS:
-            click.echo(
-                f"Unknown region {region!r}; expected one of {sorted(REGION_HOSTS)}", err=True)
-            return 1
         client_base_url = REGION_HOSTS[region]
 
     # Create client and authenticate
     try:
-        click.echo(f"Authenticating with Coros...")
+        click.echo("Authenticating with Coros...")
         client = CorosClient(email=email, password=password,
-                             base_url=client_base_url)
+                              base_url=client_base_url)
         client.authenticate()
     except CorosAuthError as e:
         click.echo(f"Authentication failed: {e}", err=True)

--- a/src/corosexport/cli/backup.py
+++ b/src/corosexport/cli/backup.py
@@ -8,9 +8,18 @@ from typing import Optional
 
 import click
 
-from corosexport.client import CorosClient, CorosAuthError, CorosAPIError
+from corosexport.client import (
+    CorosClient,
+    CorosAuthError,
+    CorosAPIError,
+)
 from corosexport.backup import BackupManager
 from corosexport.models import ExportFormat
+
+REGION_HOSTS = {
+    "eu": "https://teameuapi.coros.com",
+    "us": "https://teamapi.coros.com",
+}
 
 # Configure logging
 logging.basicConfig(
@@ -40,6 +49,17 @@ logger = logging.getLogger(__name__)
     help="Coros account password (prompts if not provided)",
 )
 @click.option(
+    "--region",
+    type=click.Choice(["eu", "us"], case_sensitive=False),
+    default="eu",
+    help="Coros account region, default eu)",
+)
+@click.option(
+    "--base-url",
+    default=None,
+    help="Override the API host directly. Takes precedence over --region.",
+)
+@click.option(
     "--format",
     multiple=True,
     type=click.Choice(["fit", "tcx", "gpx", "json"], case_sensitive=False),
@@ -55,6 +75,8 @@ def main(
     backup_dir: str,
     email: str,
     password: Optional[str],
+    region: str,
+    base_url: Optional[str],
     format: tuple[str],
     verbose: bool,
 ) -> int:
@@ -85,11 +107,21 @@ def main(
     except ValueError as e:
         click.echo(f"Error: Invalid format - {e}", err=True)
         return 1
-    
+
+    if base_url:
+        client_base_url = base_url.rstrip("/")
+    else:
+        if region not in REGION_HOSTS:
+            click.echo(
+                f"Unknown region {region!r}; expected one of {sorted(REGION_HOSTS)}", err=True)
+            return 1
+        client_base_url = REGION_HOSTS[region]
+
     # Create client and authenticate
     try:
-        click.echo("Authenticating with Coros...")
-        client = CorosClient(email=email, password=password)
+        click.echo(f"Authenticating with Coros...")
+        client = CorosClient(email=email, password=password,
+                             base_url=client_base_url)
         client.authenticate()
     except CorosAuthError as e:
         click.echo(f"Authentication failed: {e}", err=True)

--- a/src/corosexport/client.py
+++ b/src/corosexport/client.py
@@ -10,11 +10,6 @@ from .models import ActivitySummary, ActivityType, ExportFormat
 
 logger = logging.getLogger(__name__)
 
-COROS_BASE_URL = "https://teameuapi.coros.com"
-AUTH_ENDPOINT = f"{COROS_BASE_URL}/account/login"
-ACTIVITIES_ENDPOINT = f"{COROS_BASE_URL}/activity/query"
-DOWNLOAD_ENDPOINT = f"{COROS_BASE_URL}/activity/detail/download"
-
 BROWSER_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
     "Accept": "application/json, text/plain, */*",
@@ -54,9 +49,18 @@ def _compute_coros_bcrypt(password: str, *, salt: Optional[bytes] = None) -> tup
 
 
 class CorosClient:
-    def __init__(self, email: str, password: str, timeout: int = 30):
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        base_url: str,
+        timeout: int = 30,
+    ):
         self.email = email
         self.password = password
+        self.auth_endpoint = f"{base_url}/account/login"
+        self.activities_endpoint = f"{base_url}/activity/query"
+        self.download_endpoint = f"{base_url}/activity/detail/download"
         self.timeout = timeout
         self.session = requests.Session()
         self.session.headers.update(BROWSER_HEADERS)
@@ -99,7 +103,7 @@ class CorosClient:
 
         try:
             response = self.session.post(
-                AUTH_ENDPOINT, json=payload, timeout=self.timeout
+                self.auth_endpoint, json=payload, timeout=self.timeout
             )
             response.raise_for_status()
 
@@ -131,7 +135,7 @@ class CorosClient:
             "accesstoken": self.accesstoken,
             "yfheader": f'{{"userId":"{self.user_id}"}}'
         }
-        response = self.session.get(ACTIVITIES_ENDPOINT, params=params, headers=headers)
+        response = self.session.get(self.activities_endpoint, params=params, headers=headers)
         response.raise_for_status()
         
         data = response.json()
@@ -144,7 +148,7 @@ class CorosClient:
 
         for page in range(2, total_pages + 1):
             params["pageNumber"] = page
-            response = self.session.get(ACTIVITIES_ENDPOINT, params=params, headers=headers)
+            response = self.session.get(self.activities_endpoint, params=params, headers=headers)
             response.raise_for_status()
             data = response.json()
             self._check_api_response(data)
@@ -185,7 +189,7 @@ class CorosClient:
             "accesstoken": self.accesstoken,
             "yfheader": f'{{"userId":"{self.user_id}"}}'
         }
-        response = self.session.get(DOWNLOAD_ENDPOINT, params=params, headers=headers)
+        response = self.session.get(self.download_endpoint, params=params, headers=headers)
         response.raise_for_status()
         
         # Check if response is JSON (error response) or binary (file content)

--- a/src/corosexport/client.py
+++ b/src/corosexport/client.py
@@ -53,7 +53,7 @@ class CorosClient:
         self,
         email: str,
         password: str,
-        base_url: str,
+        base_url: str = "https://teameuapi.coros.com",
         timeout: int = 30,
     ):
         self.email = email


### PR DESCRIPTION
https://teamapi.coros.com seems to be the correct base URL for my US based account. 

This PR adds a --region option to specify the eu or us region and a --base-url option to specify any base URL. 

It's possible that the teamapi.coros.com domain is correct for all NON-EU accounts, but I can't really confirm that since I only have access to a US based coros account. 